### PR TITLE
added labels to VMs

### DIFF
--- a/instance-template.tf
+++ b/instance-template.tf
@@ -40,6 +40,7 @@ module "blaise_instance_template" {
   auto_delete          = true
   subnetwork           = data.google_compute_subnetwork.default.self_link
   tags                 = var.vm_tags
+  labels               = merge(var.vm_labels, {"blaise.server_park": var.server_park_name})
 
   access_config = [
     {

--- a/umig.tf
+++ b/umig.tf
@@ -77,6 +77,7 @@ resource "google_compute_instance_from_template" "instance" {
     var.labels,
     {
       name = each.key
+      type = "server-park"
     }
   )
 }


### PR DESCRIPTION
add VM labels to the instances so we can filter by blaise, serverpark and serverpark name