### PR TITLE
Paramaterise the Source Image

### DIFF
--- a/instance-template.tf
+++ b/instance-template.tf
@@ -33,8 +33,8 @@ module "blaise_instance_template" {
   name_prefix          = var.server_park_name
   project_id           = var.project_id
   machine_type         = var.vm_machine_type
-  source_image_family  = "windows-2019"
-  source_image_project = "windows-cloud"
+  source_image_family  = var.source_image_family
+  source_image_project = var.source_image_project
   disk_type            = "pd-ssd"
   disk_size_gb         = 100
   auto_delete          = true

--- a/variables.tf
+++ b/variables.tf
@@ -80,6 +80,16 @@ variable vm_machine_type {
   default = "n2-highmem-2"
 }
 
+variable source_image_family {
+  type    = string
+  default = "windows-2019"
+}
+
+variable source_image_project {
+  type    = string
+  default = "windows-cloud"
+}
+
 variable server_park_name {
   type        = string
   description = "server park name"


### PR DESCRIPTION
This change allows the source image family and project to be overridden from the default values held within the module. This has been done to enable a PR in the blaise-terraform repo.
Keeping default values means that they don't have to be parsed but can be if required.