### PR TITLE
Enable MySQL

### DIFF
--- a/umig.tf
+++ b/umig.tf
@@ -44,6 +44,7 @@ resource "google_compute_instance_from_template" "instance" {
       "BLAISE_GCP_BUCKET"         = var.blaise_install_distributables_bucket,
       "BLAISE_WINDOWS_USERNAME"   = var.windows_username,
       "BLAISE_WINDOWS_PASSWORD"   = random_password.windows_password.result,
+      "BLAISE_CLOUDSQL_CONNECT"   = var.cloudsql_connection,
       "ENV_PROJECT_ID"            = var.project_id
       "ENV_BLAISE_ADMIN_USER"     = var.blaise_admin_username,
       "ENV_BLAISE_ADMIN_PASSWORD" = random_password.blaise_admin_password.result,

--- a/umig.tf
+++ b/umig.tf
@@ -44,7 +44,7 @@ resource "google_compute_instance_from_template" "instance" {
       "BLAISE_GCP_BUCKET"         = var.blaise_install_distributables_bucket,
       "BLAISE_WINDOWS_USERNAME"   = var.windows_username,
       "BLAISE_WINDOWS_PASSWORD"   = random_password.windows_password.result,
-      "BLAISE_CLOUDSQL_CONNECT"   = var.cloudsql_connection,
+      "BLAISE_CLOUDSQL_CONNECT"   = var.cloudsql_connect,
       "ENV_PROJECT_ID"            = var.project_id
       "ENV_BLAISE_ADMIN_USER"     = var.blaise_admin_username,
       "ENV_BLAISE_ADMIN_PASSWORD" = random_password.blaise_admin_password.result,

--- a/umig.tf
+++ b/umig.tf
@@ -45,6 +45,8 @@ resource "google_compute_instance_from_template" "instance" {
       "BLAISE_WINDOWS_USERNAME"   = var.windows_username,
       "BLAISE_WINDOWS_PASSWORD"   = random_password.windows_password.result,
       "BLAISE_CLOUDSQL_CONNECT"   = var.cloudsql_connect,
+      "BLAISE_CLOUDSQL_USER"      = var.cloudsql_user,
+      "BLAISE_CLOUDSQL_PW"        = var.cloudsql_pw,
       "ENV_PROJECT_ID"            = var.project_id
       "ENV_BLAISE_ADMIN_USER"     = var.blaise_admin_username,
       "ENV_BLAISE_ADMIN_PASSWORD" = random_password.blaise_admin_password.result,

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,7 @@ variable blaise_activation_code { type = string }
 variable blaise_admin_username { type = string }
 #variable blaise_admin_password { type = string }
 variable blaise_install_distributables_bucket { type = string }
+variable cloudsql_connect { type = string }
 
 variable windows_username {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -27,7 +27,11 @@ variable blaise_activation_code { type = string }
 variable blaise_admin_username { type = string }
 #variable blaise_admin_password { type = string }
 variable blaise_install_distributables_bucket { type = string }
+
+#CloudSQL Information
 variable cloudsql_connect { type = string }
+variable cloudsql_user { type = string }
+variable cloudsql_pw { type = string }
 
 variable windows_username {
   type        = string

--- a/vm-scripts/winvm-init-script.ps1
+++ b/vm-scripts/winvm-init-script.ps1
@@ -210,8 +210,18 @@ SetupAzure
 #################
 # INSTALL IIS
 #################
-Write-Host "Installing ISS..."
+Write-Host "Installing IIS..."
 Install-WindowsFeature -Name Web-Server -IncludeAllSubFeature
+
+#########################
+# INSTALL CLOUDSQL PROXY
+#########################
+Write-Host "Copying "
+gsutil cp "gs://$GCP_BUCKET/nssm.exe" "C:\Windows\nssm.exe"
+gsutil cp "gs://$GCP_BUCKET/cloud_sql_proxy_x64.exe" "C:\Windows\cloud_sql_proxy_x64.exe"
+nssm install cloudsql_proxy C:\Windows\cloud_sql_proxy_x64.exe -instances="$CLOUDSQL_CONNECT=tcp:3306" -ip_address_types=PRIVATE
+nssm set cloudsql_proxy Start SERVICE_AUTO_START
+nssm start cloudsql_proxy
 
 #################
 # INSTALL BLAISE

--- a/vm-scripts/winvm-init-script.ps1
+++ b/vm-scripts/winvm-init-script.ps1
@@ -213,6 +213,15 @@ SetupAzure
 Write-Host "Installing IIS..."
 Install-WindowsFeature -Name Web-Server -IncludeAllSubFeature
 
+##################################
+# INSTALL MYSQL DOT NET CONNECTOR
+##################################
+Write-Host "Installing MYSQL DOT NET CONNECTOR..."
+gsutil cp gs://$GCP_BUCKET/mysql-connector-net-8.0.22.msi "C:\dev\data"
+
+Start-Process msiexec.exe -Wait -ArgumentList '/I C:\dev\data\mysql-connector-net-8.0.22.msi /quiet'
+
+
 #########################
 # INSTALL CLOUDSQL PROXY
 #########################

--- a/vm-scripts/winvm-init-script.ps1
+++ b/vm-scripts/winvm-init-script.ps1
@@ -225,7 +225,7 @@ Start-Process msiexec.exe -Wait -ArgumentList '/I C:\dev\data\mysql-connector-ne
 #########################
 # INSTALL CLOUDSQL PROXY
 #########################
-Write-Host "Copying "
+Write-Host "Installing CloudSQL Proxy and NSSM Process"
 gsutil cp "gs://$GCP_BUCKET/nssm.exe" "C:\Windows\nssm.exe"
 gsutil cp "gs://$GCP_BUCKET/cloud_sql_proxy_x64.exe" "C:\Windows\cloud_sql_proxy_x64.exe"
 nssm install cloudsql_proxy C:\Windows\cloud_sql_proxy_x64.exe -instances="$CLOUDSQL_CONNECT=tcp:3306" -ip_address_types=PRIVATE


### PR DESCRIPTION
This PR brings additional Cloudsql information (connection string, db username and db password) into the module. It also installs the MySQL dot Net connector (needed by blaise) and installs and configures the CloudSQL Proxy as a Service.
The other part of this work is here: https://github.com/ONSdigital/blaise-terraform/pull/67

Once this code has been merged it will be tagged as a new version before the upstream terraform has it's reference updated to reflect the changes.

This work has been deployed to ons-blaise-v2-dev-ali-50 where it is available for testing.