### PR TITLE
LU-8065 serverpark wiring

### DIFF
--- a/examples/frontend-backend/versions.tf
+++ b/examples/frontend-backend/versions.tf
@@ -1,11 +1,11 @@
 terraform {
   backend "gcs" {
   }
-  required_version = "0.12.28"
+  required_version = "> 0.12.28"
 }
 
 provider "google" {
-  version = "3.42.0"
+  version = "> 3.42.0"
   project = var.project_id
   region  = var.region
 }

--- a/examples/full/versions.tf
+++ b/examples/full/versions.tf
@@ -1,11 +1,11 @@
 terraform {
   backend "gcs" {
   }
-  required_version = "0.12.28"
+  required_version = "> 0.12.28"
 }
 
 provider "google" {
-  version = "3.42.0"
+  version = "> 3.42.0"
   project = var.project_id
   region  = var.region
 }

--- a/examples/single-node/versions.tf
+++ b/examples/single-node/versions.tf
@@ -1,11 +1,11 @@
 terraform {
   backend "gcs" {
   }
-  required_version = "0.12.28"
+  required_version = "> 0.12.28"
 }
 
 provider "google" {
-  version = "3.42.0"
+  version = "> 3.42.0"
   project = var.project_id
   region  = var.region
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,11 +5,18 @@ output service_account {
 
 output instances {
   description = "map of instance data used by the reverse proxy"
-  value = [for idx, instance in google_compute_instance_from_template.instance :
-    { name : instance.name,
+  value = {for idx, instance in google_compute_instance_from_template.instance :
+    idx => { name : instance.name,
       hostname : instance.name,
       fq_internal_name : "${instance.name}.${instance.zone}.c.${var.project_id}.internal"
     }
+  }
+}
+
+output web_instances {
+  description = "map of instance data where instances have the 'web' role"
+  value = [for idx, instance in google_compute_instance_from_template.instance : instance.name
+    if contains(split(local.role_label_concatenation_char, lookup(instance.labels, "blaise_server_park_roles", "")), "webserver")
   ]
 }
 

--- a/umig.tf
+++ b/umig.tf
@@ -1,3 +1,7 @@
+locals {
+  role_label_concatenation_char = "-"
+}
+
 resource "random_id" "name_suffix" {
   count       = length(var.instances)
   byte_length = 4
@@ -80,7 +84,9 @@ resource "google_compute_instance_from_template" "instance" {
     {
       name = each.key
       type = "server-park"
-      "server_park_name" = var.server_park_name
+      "server_park_name" = var.server_park_name # deprecate this
+      "blaise_server_park_name" = var.server_park_name
+      "blaise_server_park_roles" = join(local.role_label_concatenation_char, each.value.roles)
     }
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -153,7 +153,7 @@ locals {
     "BLAISE_INSTALLDIR"                  = "\"C:\\Blaise5\"",
     "BLAISE_DEPLOYFOLDER"                = "\"D:\\Blaise5\"",
     "BLAISE_INSTALLATIONTYPE"            = "Server",
-    "BLAISE_VERSION"                     = var.blaise_version,
+    "BLAISE_INTALLER_VERSION"            = var.blaise_version,
 
     # roles
     "BLAISE_MANAGEMENTSERVER" = 0,

--- a/variables.tf
+++ b/variables.tf
@@ -134,7 +134,7 @@ variable management_communication_port {
   default     = 8033
 }
 
-variable version {
+variable blaise_version {
   type        = string
   description = "Blaise version"
 
@@ -153,7 +153,7 @@ locals {
     "BLAISE_INSTALLDIR"                  = "\"C:\\Blaise5\"",
     "BLAISE_DEPLOYFOLDER"                = "\"D:\\Blaise5\"",
     "BLAISE_INSTALLATIONTYPE"            = "Server",
-    "BLAISE_VERSION"                     = var.version,
+    "BLAISE_VERSION"                     = var.blaise_version,
 
     # roles
     "BLAISE_MANAGEMENTSERVER" = 0,

--- a/variables.tf
+++ b/variables.tf
@@ -140,7 +140,7 @@ variable version {
 
   validation {
     condition     = contains(["5.7.7", "5.8.7", "5.9.1"], var.version)
-    error_message = "unsupported Blaise version"
+    error_message = "Unsupported Blaise version."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -134,6 +134,15 @@ variable management_communication_port {
   default     = 8033
 }
 
+variable version {
+  type        = string
+  description = "Blaise version"
+
+  validation {
+    condition     = contains(["5.7.7", "5.8.7", "5.9.1"], var.version)
+    error_message = "unsupported Blaise version"
+  }
+}
 
 locals {
   blaise_install_vars = {
@@ -144,6 +153,7 @@ locals {
     "BLAISE_INSTALLDIR"                  = "\"C:\\Blaise5\"",
     "BLAISE_DEPLOYFOLDER"                = "\"D:\\Blaise5\"",
     "BLAISE_INSTALLATIONTYPE"            = "Server",
+    "BLAISE_VERSION"                     = var.version,
 
     # roles
     "BLAISE_MANAGEMENTSERVER" = 0,

--- a/variables.tf
+++ b/variables.tf
@@ -139,7 +139,7 @@ variable blaise_version {
   description = "Blaise version"
 
   validation {
-    condition     = contains(["5.7.7", "5.8.7", "5.9.1"], var.version)
+    condition     = contains(["5.7.7", "5.8.7", "5.9.1"], var.blaise_version)
     error_message = "Unsupported Blaise version."
   }
 }

--- a/vm-scripts/winvm-init-script.ps1
+++ b/vm-scripts/winvm-init-script.ps1
@@ -237,31 +237,31 @@ Write-Host "INSTALLDIR: $INSTALLDIR"
 Write-Host "DEPLOYFOLDER: $DEPLOYFOLDER"
 Write-Host "SERVERPARK: $SERVERPARK"
 Write-Host "GCP_BUCKET: $GCP_BUCKET"
-Write-Host "BLAISE_VERSION: $BLAISE_VERSION"
+Write-Host "INSTALLER_VERSION: $INSTALL_VERSION"
 
-$DEFAULT_BLAISE_INSTALLER_FILENAME="Blaise5_7_7_2284.zip"
+$DEFAULT_INSTALLER_FILENAME="Blaise5_7_7_2284.zip"
 
-if ( $BLAISE_VERSION -eq "5.7.7" ) {
-  $BLAISE_INSTALLER_FILENAME="Blaise5_7_7_2284.zip"
+if ( $INSTALLER_VERSION -eq "5.7.7" ) {
+  $INSTALLER_FILENAME="Blaise5_7_7_2284.zip"
 }
-elseif ( $BLAISE_VERSION -eq "5.8.7" ) {
-  $BLAISE_INSTALLER_FILENAME="Blaise5_8_7_2522.zip"
+elseif ( $INSTALLER_VERSION -eq "5.8.7" ) {
+  $INSTALLER_FILENAME="Blaise5_8_7_2522.zip"
 }
-elseif ( $BLAISE_VERSION -eq "5.9.1" ) {
-  $BLAISE_INSTALLER_FILENAME="Blaise5_9_1_2637.zip"
+elseif ( $INSTALLER_VERSION -eq "5.9.1" ) {
+  $INSTALLER_FILENAME="Blaise5_9_1_2637.zip"
 }
 else {
-  Write-Host "BLAISE_INSTALLER_FILENAME not set, using default"
-  $BLAISE_INSTALLER_FILENAME=$DEFAULT_BLAISE_INSTALLER_FILENAME
+  Write-Host "INSTALLER_FILENAME not set, using default"
+  $INSTALLER_FILENAME=$DEFAULT_INSTALLER_FILENAME
 }
 
-Write-Host "Download Blaise installer from '$GCP_BUCKET/$BLAISE_INSTALLER_FILENAME'"
-gsutil cp gs://$GCP_BUCKET/$BLAISE_INSTALLER_FILENAME "C:\dev\data"
+Write-Host "Download Blaise installer from '$GCP_BUCKET/$INSTALLER_FILENAME'"
+gsutil cp gs://$GCP_BUCKET/$INSTALLER_FILENAME "C:\dev\data"
 
 # unzip blaise installer
 Write-Host "Expanding archive to 'Blaise' dir"
 mkdir C:\dev\data\Blaise
-Expand-Archive -Force C:\dev\data\$BLAISE_INSTALLER_FILENAME C:\dev\data\Blaise\
+Expand-Archive -Force C:\dev\data\$INSTALLER_FILENAME C:\dev\data\Blaise\
 
 Write-Host "Setting Blaise install args"
 $blaise_args = "/qn","/norestart","/log C:\dev\data\Blaise5-install.log","/i C:\dev\data\Blaise\Blaise5.msi"

--- a/vm-scripts/winvm-init-script.ps1
+++ b/vm-scripts/winvm-init-script.ps1
@@ -237,14 +237,31 @@ Write-Host "INSTALLDIR: $INSTALLDIR"
 Write-Host "DEPLOYFOLDER: $DEPLOYFOLDER"
 Write-Host "SERVERPARK: $SERVERPARK"
 Write-Host "GCP_BUCKET: $GCP_BUCKET"
+Write-Host "BLAISE_VERSION: $BLAISE_VERSION"
 
-Write-Host "Download Blaise redistributables from '$GCP_BUCKET'"
-gsutil cp gs://$GCP_BUCKET/Blaise5_7_7_2284.zip "C:\dev\data"
+$DEFAULT_BLAISE_INSTALLER_FILENAME="Blaise5_7_7_2284.zip"
+
+if ( $BLAISE_VERSION -eq "5.7.7" ) {
+  $BLAISE_INSTALLER_FILENAME="Blaise5_7_7_2284.zip"
+}
+elseif ( $BLAISE_VERSION -eq "5.8.7" ) {
+  $BLAISE_INSTALLER_FILENAME="Blaise5_8_7_2522.zip"
+}
+elseif ( $BLAISE_VERSION -eq "5.9.1" ) {
+  $BLAISE_INSTALLER_FILENAME="Blaise5_9_1_2637.zip"
+}
+else {
+  Write-Host "BLAISE_INSTALLER_FILENAME not set, using default"
+  $BLAISE_INSTALLER_FILENAME=$DEFAULT_BLAISE_INSTALLER_FILENAME
+}
+
+Write-Host "Download Blaise installer from '$GCP_BUCKET/$BLAISE_INSTALLER_FILENAME'"
+gsutil cp gs://$GCP_BUCKET/$BLAISE_INSTALLER_FILENAME "C:\dev\data"
 
 # unzip blaise installer
 Write-Host "Expanding archive to 'Blaise' dir"
 mkdir C:\dev\data\Blaise
-Expand-Archive -Force C:\dev\data\Blaise5_7_7_2284.zip C:\dev\data\Blaise\
+Expand-Archive -Force C:\dev\data\$BLAISE_INSTALLER_FILENAME C:\dev\data\Blaise\
 
 Write-Host "Setting Blaise install args"
 $blaise_args = "/qn","/norestart","/log C:\dev\data\Blaise5-install.log","/i C:\dev\data\Blaise\Blaise5.msi"


### PR DESCRIPTION
features
+ instances output variable is a dictionary (previously was list)
+ added node role information to vm-labels (limitations on string concatenation from GCP bit frustrating, not sure if there is a standard, have concatenated with a hyphen)
+ added "blaise_version" module variable which will control the installer used in the install script

updates
+ examples had tight constraints on version